### PR TITLE
SRE-349-ansible-role-zfs-handle-pool-created-by-previous-os-install

### DIFF
--- a/tasks/create-pool.yml
+++ b/tasks/create-pool.yml
@@ -3,6 +3,7 @@
   ansible.builtin.command: >
     zpool import -a
   failed_when: false
+  changed_when: false
 
 - name: Detect zfs pool
   community.general.zpool_facts:

--- a/tasks/create-pool.yml
+++ b/tasks/create-pool.yml
@@ -1,4 +1,9 @@
 ---
+- name: Import existing zfs pools
+  ansible.builtin.command: >
+    zpool import -a
+  failed_when: false
+
 - name: Detect zfs pool
   community.general.zpool_facts:
     name: "{{ item.key }}"


### PR DESCRIPTION
if zpools exist, try to import them, rather than recreate (which will fail w/o additional parameters)