### PR TITLE
Pin kernel-devel to the running kernel for DKMS builds

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,9 +16,9 @@
     dnf config-manager --enable zfs
   changed_when: false
 
-- name: Install kernel-devel package
+- name: Install kernel-devel matching the running kernel
   ansible.builtin.dnf:
-    name: kernel-devel
+    name: "kernel-devel-{{ ansible_facts['kernel'] }}"
     state: present
 
 - name: Install zfs package


### PR DESCRIPTION
## Problem

`modprobe zfs` fails right after provisioning with:

modprobe: FATAL: Module zfs not found in directory /lib/modules/<running-kernel>

The role installed the **unversioned** `kernel-devel`, which dnf resolves to the newest release in the repo. When a host boots an older kernel than the latest available (common right after provisioning, before a full update + reboot), DKMS gets headers for a kernel it isn't running:

- Running kernel: `5.14.0-687.19.1.el9_8`
- `kernel-devel` pulled: `5.14.0-687.23.1.el9_8`
- `/usr/src/kernels/` only has the `687.23.1` tree → DKMS can't build `zfs.ko` for the running kernel → nothing in `/lib/modules/5.14.0-687.19.1.el9_8.x86_64/`.

## Fix

Pin `kernel-devel` to `ansible_facts['kernel']` (`uname -r`) so DKMS always has headers matching the **running** kernel, regardless of newer kernels in the repo.

## Testing

Verified on chk03.dw2.rmge.net: `kernel-devel-5.14.0-687.19.1.el9_8` is available in appstream; installing it + `dkms autoinstall` + `modprobe zfs` is the manual equivalent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
